### PR TITLE
feat: dockerized LaTeX environment in VS Code

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -24,7 +24,7 @@
   "latex-workshop.latex.rootFile.useSubFile": true,
   "latex-workshop.message.latexlog.exclude": [
     "Infinite glue shrinkage found in box being split"
-  ],  // TeX Live 2025...
+  ],  // TeX Live 2025 triggers this 'ignored error' when a longtable is split across pages.
   "latex-workshop.latex.autoBuild.run": "onSave",
   "latex-workshop.latex.recipe.default": "lastUsed",
   "latex-workshop.latex.tools": [
@@ -80,6 +80,7 @@
       "tools": ["docker-latexmk"]
     }
   ],
+  
   // Typst
   "tinymist.outputPath": "$dir/build/$name"
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -24,7 +24,9 @@
   "latex-workshop.latex.rootFile.useSubFile": true,
   "latex-workshop.message.latexlog.exclude": [
     "Infinite glue shrinkage found in box being split"
-  ],  // TeX Live 2025 triggers this 'ignored error' when a longtable is split across pages.
+  ],  // TeX Live 2025...
+  "latex-workshop.latex.autoBuild.run": "onSave",
+  "latex-workshop.latex.recipe.default": "lastUsed",
   "latex-workshop.latex.tools": [
     {
       "name": "latexmk",
@@ -43,9 +45,41 @@
       "env": {
         "TEXINPUTS": "%WORKSPACE_FOLDER%/lib/latex//;%WORKSPACE_FOLDER%/resources//;"
       }
+    },
+    {
+      "name": "docker-latexmk",
+      "command": "docker",
+      "args": [
+        "run",
+        "--rm",
+        "-v",
+        "%WORKSPACE_FOLDER%:/work",
+        "-w",
+        "/work/%RELATIVE_DIR%",
+        "-e",
+        "TEXINPUTS=/work/lib/latex//:/work/resources//:",
+        "ghcr.io/munuchapterhkn/eta-kappa-notes/texlive",
+        "latexmk",
+        "-cd",
+        "-r",
+        "/work/lib/latex/latexmkrc",
+        "-shell-escape",
+        "-pdf",
+        "-outdir=build",
+        "%DOCFILE%"
+      ]
     }
   ],
-
+  "latex-workshop.latex.recipes": [
+    {
+      "name": "latexmk",
+      "tools": ["latexmk"]
+    },
+    {
+      "name": "docker-latexmk",
+      "tools": ["docker-latexmk"]
+    }
+  ],
   // Typst
   "tinymist.outputPath": "$dir/build/$name"
 }


### PR DESCRIPTION
Expands the VSCode `settings.json` file to enable the use of the LaTex compiler and Inkscape environment inside a Docker container, without relying on dependencies installed on the host system.
The default Docker image is the same used for notes compilations for the note releases.

The user keeps the ability of selecting the preferred compilation environment using the VSCode LaTeX extension. Then, every subsequent file save triggers the last used environment, to preserve the use of shortcuts while writing texts.